### PR TITLE
Fix context warning and port method error

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -171,12 +171,12 @@ Test::TCP::test_tcp(
 
         get '/destroy_session' => sub {
             my $name = session('name') || '';
-            context->destroy_session;
+            app->destroy_session;
             return "destroyed='$name'";
         };
 
         get '/churn_session' => sub {
-            context->destroy_session;
+            app->destroy_session;
             session name => 'damian';
             return "churned";
         };
@@ -208,7 +208,7 @@ Test::TCP::test_tcp(
             port         => $port
         );
 
-        Dancer2->runner->server->port($port);
+        Dancer2->runner->server->{'port'} = $port;
         start;
     },
 );


### PR DESCRIPTION
From test output:

> DEPRECATED: please use the 'app' keyword instead of 'context'
> Can't locate object method "port" via package "HTTP::Server::PSGI" at t/basic.t line 211