### PR TITLE
Optionnal croaking on cluster unreachable

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -19,6 +19,7 @@ version 0.003
     session:
       Memcached:
         memcached_servers: 10.0.1.31:11211,10.0.1.32:11211,/var/sock/memcached
+        fatal_cluster_unreachable: 0
 
 =head1 DESCRIPTION
 
@@ -31,6 +32,10 @@ state within Memcached using L<Cache::Memcached>.
 
 A comma-separated list of reachable memcached servers (can be either
 address:port or socket paths).
+
+=head2 fatal_cluster_unreachable (optional default 0)
+
+Boolean (0|1), if memcache cluster is not reachable and fatal_cluster_unreachable is set to 1, application will croak
 
 =for Pod::Coverage method_names_here
 

--- a/lib/Dancer2/Session/Memcached.pm
+++ b/lib/Dancer2/Session/Memcached.pm
@@ -103,6 +103,7 @@ sub _sessions {
     session:
       Memcached:
         memcached_servers: 10.0.1.31:11211,10.0.1.32:11211,/var/sock/memcached
+        fatal_cluster_unreachable: 0
 
 =head1 DESCRIPTION
 

--- a/lib/Dancer2/Session/Memcached.pm
+++ b/lib/Dancer2/Session/Memcached.pm
@@ -28,6 +28,13 @@ has memcached_servers => (
     required => 1,
 );
 
+has fatal_cluster_unreachable => (
+    is       => 'ro',
+    isa      => Bool,
+    required => 0,
+    default  => sub { 0 },
+);
+
 #--------------------------------------------------------------------------#
 # Private attributes
 #--------------------------------------------------------------------------#
@@ -60,7 +67,12 @@ sub _build__memcached {
         }
     }
 
-    return Cache::Memcached->new( servers => $servers );
+    my $cache_engine = Cache::Memcached->new( servers => $servers );
+
+    croak "Memcache cluster unreachable"
+        if $self->fatal_cluster_unreachable && not keys %{$cache_engine->stats(['misc'])};
+
+    return $cache_engine;
 }
 
 #--------------------------------------------------------------------------#


### PR DESCRIPTION
Right now the session plugin is failing silently if memcache server is not reachable. Data are not stored in session without any warnings.
Addition of a parameter "fatal_cluster_unreachable" to croak if cluster is not reachable.

The default behaviour is not changed, by default it will still fail silently.

The way to check if cluster is reachable is far from good, but it does its work.
